### PR TITLE
angular-io-quickstart to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,3 +16,6 @@ dependencies:
 - name: spring-boot-rest-prometheus
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: angular-io-quickstart
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1


### PR DESCRIPTION
Promote angular-io-quickstart to version 0.0.1